### PR TITLE
Copy the ItemStack regardless of its contents

### DIFF
--- a/src/main/java/org/dave/ocxnetdriver/driver/controller/EnvironmentXnetController.java
+++ b/src/main/java/org/dave/ocxnetdriver/driver/controller/EnvironmentXnetController.java
@@ -359,11 +359,7 @@ public class EnvironmentXnetController extends AbstractManagedEnvironment implem
         List<ItemStack> result = new ArrayList<>();
         for(int slot = 0; slot < handler.getSlots(); slot++) {
             ItemStack stack = handler.getStackInSlot(slot);
-            if(stack.isEmpty()) {
-                result.add(null);
-            } else {
-                result.add(stack.copy());
-            }
+            result.add(stack.copy());
         }
 
         return new Object[]{ result };


### PR DESCRIPTION
When iterating over a table of inventory slots in lua, the iteration
operation ends when null is encountered, as there is no conversion from
null to nil. Directly referencing a table element that represents an
empty inventory slot also causes a traceback to occur.

This commit copies all ItemStacks, even empty ones, which are in fact
ItemStack.EMPTY, and can be identified by the name minecraft:air in lua
programs. Doing this allows iteration over a table representing an
inventory to complete successfully, and direct referencing of all table
elements is possible.

How to test:
1. Set up a computer with screen, keyboard, and OpenOS. Recommended to use tier 3 screen/GPU so the full output of the script is viewable.
2. Set up an XNet controller connected to a chest, energy is not required.
3. Place 2 or more items in the chest, making sure to leave an empty slot between one or more of the items. Example being something in slots 1 and 2, leave 3 empty, and put something in slot 4.
3. Place an adapter next to the XNet controller, and connect it to the computer.
4. Use the following script:

Running this script against a build of the mod from git master, you will notice the iteration stops at the empty slot, and the script will only report the slots it found items in before encountering something that it doesn't know how to deal with.

Running this script against my branch will allow the iteratino to complete successfully, reporting number of filled slots, and number of total slots.

```lua
local component = require("component")
local sides = require("sides")
local xnet = component.xnet

-- Get the chest position
local blocks = xnet.getConnectedBlocks()
if blocks[1].name ~= "minecraft:chest" then
  return
end

local chest = blocks[1]

-- Iterate over the chest contents.
local inv = xnet.getItems(chest.pos, sides[chest.side])
local slots = inv.n
local filled = 0

for s, slot in ipairs(inv) do
  if slot.name ~= "minecraft:air" then
    filled = filled + 1
  end
  print(s .. ": " .. slot.name)
end

print("Total slots: " .. slots)
print("Slots filled: " .. filled)
```